### PR TITLE
Fix: hostname resolution and amp.conf management on NixOS

### DIFF
--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -170,10 +170,14 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
-        # hostname and dmidecode are not at standard FHS paths on NixOS.
-        # Point symlinks directly to the nix store path (NOT /run/current-system/sw/bin)
+        # hostname is not at a standard FHS path on NixOS. konea (precompiled Ubuntu
+        # binary) calls hostname via a hardcoded PATH=/usr/bin:/bin, so we need
+        # symlinks in all three locations. Point directly to the nix store path
         # so they are never dangling regardless of environment.systemPackages.
         "L+ /usr/local/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /usr/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
         "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -98,6 +98,12 @@ in
       description = "KACE SMA host (written to amp.conf).";
     };
 
+    name = mkOption {
+      type = types.str;
+      default = config.networking.hostName;
+      description = "Machine name reported to KBOX (defaults to networking.hostName).";
+    };
+
     ampConf = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -161,7 +167,7 @@ in
         else
           printf '%s\n' '${k}=${v}' >> "$CONF"
         fi
-      '') ({ host = cfg.host; } // cfg.ampConf))}
+      '') ({ host = cfg.host; name = cfg.name; } // cfg.ampConf))}
     '';
 
     # === konea: runs as daemon with -start ===

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -13,6 +13,7 @@ let
     pkgs.gnugrep      # grep
     pkgs.gnused       # sed
     pkgs.findutils    # find, xargs
+    pkgs.inetutils    # hostname - needed by inventory scripts
   ];
 
   # Environment: build systemd-friendly env list
@@ -142,7 +143,26 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
+        # hostname is not at a standard FHS path on NixOS; inventory scripts
+        # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
+        "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
+
+    # === Write NixOS-managed keys into amp.conf ===
+    # Merges host= and any ampConf entries into the live amp.conf on every
+    # nixos-rebuild switch, preserving all other keys pushed down by KBOX.
+    system.activationScripts.kace-ampconf = ''
+      mkdir -p "${cfg.dataDir}"
+      CONF="${cfg.dataDir}/amp.conf"
+      touch "$CONF"
+      ${concatStringsSep "\n" (mapAttrsToList (k: v: ''
+        if ${pkgs.gnugrep}/bin/grep -q "^${k}=" "$CONF"; then
+          ${pkgs.gnused}/bin/sed -i 's|^${k}=.*|${k}=${v}|' "$CONF"
+        else
+          printf '%s\n' '${k}=${v}' >> "$CONF"
+        fi
+      '') ({ host = cfg.host; } // cfg.ampConf))}
+    '';
 
     # === konea: runs as daemon with -start ===
     systemd.services.konea = {

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -32,6 +32,21 @@ let
   # Path to kace binaries
   kaceBinDir = "${cfg.package}/opt/quest/kace/bin";
 
+  # Script that re-applies NixOS-managed keys to amp.conf.
+  # Runs after a delay so it fires after KBOX pushes its config on connect,
+  # which would otherwise clobber keys we set at activation time.
+  ampConfPatchScript = pkgs.writeShellScript "kace-ampconf-patch" ''
+    sleep 30
+    CONF="${cfg.dataDir}/amp.conf"
+    ${concatStringsSep "\n" (mapAttrsToList (k: v: ''
+      if ${pkgs.gnugrep}/bin/grep -q "^${k}=" "$CONF"; then
+        ${pkgs.gnused}/bin/sed -i 's|^${k}=.*|${k}=${v}|' "$CONF"
+      else
+        printf '%s\n' '${k}=${v}' >> "$CONF"
+      fi
+    '') ({ name = cfg.name; } // cfg.ampConf))}
+  '';
+
   # Helper: direct foreground execution (preferred on NixOS)
   mkKaceServiceSimple = name: desc: extraOpts:
     let
@@ -155,16 +170,18 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
-        # hostname is not at a standard FHS path on NixOS; inventory scripts
-        # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
-        "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
-        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
-        "L+ /usr/sbin/dmidecode - - - - /run/current-system/sw/bin/dmidecode"
+        # hostname and dmidecode are not at standard FHS paths on NixOS.
+        # Point symlinks directly to the nix store path (NOT /run/current-system/sw/bin)
+        # so they are never dangling regardless of environment.systemPackages.
+        "L+ /usr/local/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 
-    # === Write NixOS-managed keys into amp.conf ===
-    # Merges host= and any ampConf entries into the live amp.conf on every
-    # nixos-rebuild switch, preserving all other keys pushed down by KBOX.
+    # === Write NixOS-managed keys into amp.conf at activation time ===
+    # Handles initial setup and ensures host= is always correct.
+    # Note: KBOX pushes a fresh amp.conf on every konea connection, which
+    # clobbers keys like name=. The ExecStartPost on konea re-applies them
+    # 30 s after start (after the KBOX push settles).
     system.activationScripts.kace-ampconf = ''
       mkdir -p "${cfg.dataDir}"
       CONF="${cfg.dataDir}/amp.conf"
@@ -187,6 +204,10 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.bash}/bin/bash -c 'PATH=${finalPath} exec ${kaceBinDir}/konea'";
+        # Re-apply name= (and any ampConf keys) after KBOX pushes its config.
+        # KBOX overwrites amp.conf shortly after konea connects; 30 s is enough
+        # for that push to complete before we write our keys back.
+        ExecStartPost = ampConfPatchScript;
         KillSignal = "SIGTERM";
         KillMode = "control-group";
         TimeoutStartSec = 120;

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -14,6 +14,9 @@ let
     pkgs.gnused       # sed
     pkgs.findutils    # find, xargs
     pkgs.inetutils    # hostname - needed by inventory scripts
+    pkgs.systemd      # systemctl - needed for startup programs inventory
+    pkgs.pciutils     # lspci - needed for audio/video hardware inventory
+    pkgs.networkmanager # nmcli - needed for DHCP/network inventory
   ];
 
   # Environment: build systemd-friendly env list
@@ -145,6 +148,9 @@ in
       };
     };
 
+    # dmidecode is hardcoded to /usr/sbin/dmidecode by KInventory; ensure it is installed.
+    environment.systemPackages = [ pkgs.dmidecode ];
+
     systemd.tmpfiles.rules =
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
@@ -152,6 +158,8 @@ in
         # hostname is not at a standard FHS path on NixOS; inventory scripts
         # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
         "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
+        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
+        "L+ /usr/sbin/dmidecode - - - - /run/current-system/sw/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 
     # === Write NixOS-managed keys into amp.conf ===


### PR DESCRIPTION
Related to #23 .

Two issues prevented the KACE agent from correctly reporting the machine name to KBOX on NixOS systems:

* `hostname` is not at a standard FHS path on NixOS. Inventory scripts that reset `PATH` to `/bin:/usr/bin:/usr/local/bin` could not find it, causing `<NAME>` in inventory to be empty. Fixed by adding `pkgs.inetutils` to `kacePath` and creating a `/usr/local/bin/hostname` symlink via `systemd.tmpfiles.rules`.

* The `host` and `ampConf` options were defined but never applied to `amp.conf`. Added a `system.activationScripts` entry that merges these NixOS-managed keys into the live `amp.conf` on every nixos-rebuild switch, while preserving all other settings pushed down by the KBOX server.