### PR TITLE
Further fixes for passing hostname through to kbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ nix build .#kace-ampagent
 -   `services.kace-ampagent.linkOptPath`: Create a `/opt/quest/kace` symlink pointing to the package content for compatibility (boolean, default `true`).
 -   `services.kace-ampagent.host`: The KACE SMA host (string, required). Written to `amp.conf` as `host=`.
 -   `services.kace-ampagent.ampConf`: An attribute set of additional key-value pairs for `amp.conf` (attrset, default `{}`).
--   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset.
+-   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset. The 10 min `konea-checker` additionally restarts `KSchedulerConsole` if it is not running, because `AMPWatchDog -k` only revives konea — leaving the scheduler (which drives scheduled inventory/scripts) dead after a reset.
 
 ### Example
 
@@ -120,7 +120,7 @@ When the module is enabled, the following systemd services are created and run i
 
 5. **`ampwatchdog.timer`** and **`ampwatchdog.service`** (oneshot, optional): Runs `AMPWatchDog` every 6 h when `enableWatchdog = true` — independently of `konea.service`
 
-6. **`konea-checker.timer`** and **`konea-checker.service`** (oneshot, optional): Runs `AMPWatchDog -k` every 10 min when `enableWatchdog = true` — independently of `konea.service`
+6. **`konea-checker.timer`** and **`konea-checker.service`** (oneshot, optional): Runs `AMPWatchDog -k` every 10 min when `enableWatchdog = true` — independently of `konea.service`. Also starts `KSchedulerConsole` if it is down (covers the SMA agent-reset case where both stop cleanly and `Restart=always` never fires).
 
 ## Using the Agent Manually
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ nix build .#kace-ampagent
     -   `kace-ampagent-setup`: Creates the `amp.conf` configuration file with the host and optional settings
     -   `konea`: Main KACE agent service that runs `konea -start` as a daemon
     -   `kschedulerconsole`: Scheduler console service that starts after konea
-    -   `ampwatchdog` (optional): Standalone watchdog service when `enableWatchdog = true`
+    -   `ampwatchdog.timer` + `ampwatchdog.service` (optional): AMPWatchDog watchdog one-shot every 6 h when `enableWatchdog = true` (matches the shipped `AMPWatchDogCrontab`)
 -   `services.kace-ampagent.package`: The Nix package providing the KACE agent binaries (package, default: `pkgs.kace-ampagent` from the overlay). Leave unset so the module builds the package with your system's nixpkgs; override only if you need a different source.
 -   `services.kace-ampagent.dataDir`: The directory where the agent stores its data (string, default `/var/quest/kace`).
 -   `services.kace-ampagent.logDir`: The directory where the agent stores its logs (string, default `/var/log/quest/kace`).
@@ -86,7 +86,7 @@ nix build .#kace-ampagent
 -   `services.kace-ampagent.linkOptPath`: Create a `/opt/quest/kace` symlink pointing to the package content for compatibility (boolean, default `true`).
 -   `services.kace-ampagent.host`: The KACE SMA host (string, required). Written to `amp.conf` as `host=`.
 -   `services.kace-ampagent.ampConf`: An attribute set of additional key-value pairs for `amp.conf` (attrset, default `{}`).
--   `services.kace-ampagent.enableWatchdog`: Enable the standalone `AMPWatchDog` service (boolean, default `false`).
+-   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset.
 
 ### Example
 
@@ -118,9 +118,9 @@ When the module is enabled, the following systemd services are created and run i
 
 4. **`kschedulerconsole.service`** (simple): Runs `KSchedulerConsole` (depends on konea)
 
-5. **`ampwatchdog.service`** (simple, optional): Runs `AMPWatchDog` when `enableWatchdog = true`
+5. **`ampwatchdog.timer`** and **`ampwatchdog.service`** (oneshot, optional): Runs `AMPWatchDog` every 6 h when `enableWatchdog = true` — independently of `konea.service`
 
-6. **`konea-checker.timer`** and **`konea-checker.service`** (optional): Periodic health checks when `enableWatchdog = true`
+6. **`konea-checker.timer`** and **`konea-checker.service`** (oneshot, optional): Runs `AMPWatchDog -k` every 10 min when `enableWatchdog = true` — independently of `konea.service`
 
 ## Using the Agent Manually
 

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -170,10 +170,14 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
-        # hostname and dmidecode are not at standard FHS paths on NixOS.
-        # Point symlinks directly to the nix store path (NOT /run/current-system/sw/bin)
+        # hostname is not at a standard FHS path on NixOS. konea (precompiled Ubuntu
+        # binary) calls hostname via a hardcoded PATH=/usr/bin:/bin, so we need
+        # symlinks in all three locations. Point directly to the nix store path
         # so they are never dangling regardless of environment.systemPackages.
         "L+ /usr/local/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /usr/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
         "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -288,7 +288,7 @@ in
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
         Environment = kaceEnv;
-        ExecStart = [ "${kaceBinDir}/AMPWatchDog" ];
+        ExecStart = "${kaceBinDir}/AMPWatchDog";
         StandardOutput = "journal";
         StandardError = "journal";
       };
@@ -312,7 +312,7 @@ in
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
         Environment = kaceEnv;
-        ExecStart = [ "${kaceBinDir}/AMPWatchDog" "-k" ];
+        ExecStart = "${kaceBinDir}/AMPWatchDog -k";
         StandardOutput = "journal";
         StandardError = "journal";
       };

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -6,18 +6,25 @@ let
     mapAttrsToList concatStringsSep optional filterAttrs;
 
   # Ensure required tools are in PATH for script execution.
-  # NOTE: this only reaches the units below (konea, KSchedulerConsole). konea
-  # sanitises the environment for anything it spawns via /exec, so the chain
-  # konea -> KPlugins -> runkbot -> KBoxClient -> KInventory does NOT inherit it.
-  # Tools KInventory needs must be FHS symlinks in tmpfiles.rules, not listed here.
+  # This PATH is inherited by konea's /exec spawn chain (konea -> KPlugins ->
+  # runkbot -> KBoxClient -> KInventory): konea does NOT sanitise it. Verified
+  # 2026-08-14 by re-running KInventory with this exact PATH and reproducing the
+  # broken ~4.5KB inventory (0 CPUs) that the SMA silently discards; with lscpu
+  # on PATH the same run yields the ~33.8KB inventory the SMA accepts. Tools
+  # KInventory needs must therefore be listed HERE, not as /usr/bin FHS symlinks
+  # (the spawn PATH has no /usr/bin, so the symlinks never resolve).
   kacePath = lib.makeBinPath [
     pkgs.coreutils    # true, false, etc.
     pkgs.bash         # CRITICAL - needed to run any scripts
     pkgs.psmisc       # killall
     pkgs.gnugrep      # grep
     pkgs.gnused       # sed
+    pkgs.gawk         # awk - used by inventory shell pipelines
     pkgs.findutils    # find, xargs
     pkgs.inetutils    # hostname - needed by inventory scripts
+    pkgs.procps       # ps, free - processes and memory inventory
+    pkgs.util-linux   # lscpu - CPU inventory (0 CPUs => SMA discards the doc)
+    pkgs.iproute2     # ip - network interface inventory
     pkgs.systemd      # systemctl - needed for startup programs inventory
     pkgs.pciutils     # lspci - needed for audio/video hardware inventory
     pkgs.networkmanager # nmcli - needed for DHCP/network inventory
@@ -183,18 +190,23 @@ in
         "L+ /bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
         # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
         "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
-        # KInventory resolves these with find_cmd_in_path against konea's sanitised
-        # PATH, so kacePath above never reaches it - only FHS symlinks work.
-        # Without them KInventory emits a ~4.5KB document reporting 0 CPUs and no
-        # software, which the SMA silently discards: the upload still returns 200
-        # with an empty body, so the only symptom is Last Inventory never advancing.
-        # Verified 2026-08-06 - adding these took inventory.xml 4.5KB -> 33.8KB and
-        # unstuck a device that had not inventoried in 79 days.
+        # KInventory resolves these with find_cmd_in_path against konea's spawn
+        # PATH (= kacePath above). /usr/bin symlinks alone are NOT sufficient -
+        # the spawn PATH has no /usr/bin - but keep them for tools invoked via a
+        # hardcoded /usr/bin|/usr/sbin|/bin path (dmidecode, lsblk, bash,
+        # hostname). Without lscpu on PATH, KInventory emits a ~4.5KB document
+        # reporting 0 CPUs, which the SMA silently discards: the upload still
+        # returns 200 with an empty body, so the only symptom is Last Inventory
+        # never advancing. Note: the 2026-08-06 "symlink fix" (4.5KB -> 33.8KB)
+        # was a false positive from a manually-run KInventory (user shell PATH);
+        # konea-spawned runs stayed broken until kacePath gained the tools.
         "L+ /usr/bin/lspci - - - - ${pkgs.pciutils}/bin/lspci"
         "L+ /usr/bin/systemctl - - - - ${pkgs.systemd}/bin/systemctl"
         "L+ /usr/bin/nmcli - - - - ${pkgs.networkmanager}/bin/nmcli"
         "L+ /usr/bin/lscpu - - - - ${pkgs.util-linux}/bin/lscpu"
         "L+ /usr/bin/ip - - - - ${pkgs.iproute2}/bin/ip"
+        "L+ /usr/bin/lsblk - - - - ${pkgs.util-linux}/bin/lsblk"
+        "L+ /bin/bash - - - - ${pkgs.bash}/bin/bash"
         # Not fixable this way: rpm / dpkg-query do not exist on NixOS, so
         # INSTALLED_SOFTWARE stays empty ("Only RPM and Debian package systems
         # currently supported!"). Needs a KACE Custom Inventory Rule instead.

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -5,7 +5,11 @@ let
     mkOption mkEnableOption mkIf types
     mapAttrsToList concatStringsSep optional filterAttrs;
 
-  # Ensure required tools are in PATH for script execution
+  # Ensure required tools are in PATH for script execution.
+  # NOTE: this only reaches the units below (konea, KSchedulerConsole). konea
+  # sanitises the environment for anything it spawns via /exec, so the chain
+  # konea -> KPlugins -> runkbot -> KBoxClient -> KInventory does NOT inherit it.
+  # Tools KInventory needs must be FHS symlinks in tmpfiles.rules, not listed here.
   kacePath = lib.makeBinPath [
     pkgs.coreutils    # true, false, etc.
     pkgs.bash         # CRITICAL - needed to run any scripts
@@ -179,6 +183,21 @@ in
         "L+ /bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
         # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
         "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
+        # KInventory resolves these with find_cmd_in_path against konea's sanitised
+        # PATH, so kacePath above never reaches it - only FHS symlinks work.
+        # Without them KInventory emits a ~4.5KB document reporting 0 CPUs and no
+        # software, which the SMA silently discards: the upload still returns 200
+        # with an empty body, so the only symptom is Last Inventory never advancing.
+        # Verified 2026-08-06 - adding these took inventory.xml 4.5KB -> 33.8KB and
+        # unstuck a device that had not inventoried in 79 days.
+        "L+ /usr/bin/lspci - - - - ${pkgs.pciutils}/bin/lspci"
+        "L+ /usr/bin/systemctl - - - - ${pkgs.systemd}/bin/systemctl"
+        "L+ /usr/bin/nmcli - - - - ${pkgs.networkmanager}/bin/nmcli"
+        "L+ /usr/bin/lscpu - - - - ${pkgs.util-linux}/bin/lscpu"
+        "L+ /usr/bin/ip - - - - ${pkgs.iproute2}/bin/ip"
+        # Not fixable this way: rpm / dpkg-query do not exist on NixOS, so
+        # INSTALLED_SOFTWARE stays empty ("Only RPM and Debian package systems
+        # currently supported!"). Needs a KACE Custom Inventory Rule instead.
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 
     # === Write NixOS-managed keys into amp.conf at activation time ===

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -98,6 +98,12 @@ in
       description = "KACE SMA host (written to amp.conf).";
     };
 
+    name = mkOption {
+      type = types.str;
+      default = config.networking.hostName;
+      description = "Machine name reported to KBOX (defaults to networking.hostName).";
+    };
+
     ampConf = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -161,7 +167,7 @@ in
         else
           printf '%s\n' '${k}=${v}' >> "$CONF"
         fi
-      '') ({ host = cfg.host; } // cfg.ampConf))}
+      '') ({ host = cfg.host; name = cfg.name; } // cfg.ampConf))}
     '';
 
     # === konea: runs as daemon with -start ===

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -13,6 +13,7 @@ let
     pkgs.gnugrep      # grep
     pkgs.gnused       # sed
     pkgs.findutils    # find, xargs
+    pkgs.inetutils    # hostname - needed by inventory scripts
   ];
 
   # Environment: build systemd-friendly env list
@@ -142,7 +143,26 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
+        # hostname is not at a standard FHS path on NixOS; inventory scripts
+        # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
+        "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
+
+    # === Write NixOS-managed keys into amp.conf ===
+    # Merges host= and any ampConf entries into the live amp.conf on every
+    # nixos-rebuild switch, preserving all other keys pushed down by KBOX.
+    system.activationScripts.kace-ampconf = ''
+      mkdir -p "${cfg.dataDir}"
+      CONF="${cfg.dataDir}/amp.conf"
+      touch "$CONF"
+      ${concatStringsSep "\n" (mapAttrsToList (k: v: ''
+        if ${pkgs.gnugrep}/bin/grep -q "^${k}=" "$CONF"; then
+          ${pkgs.gnused}/bin/sed -i 's|^${k}=.*|${k}=${v}|' "$CONF"
+        else
+          printf '%s\n' '${k}=${v}' >> "$CONF"
+        fi
+      '') ({ host = cfg.host; } // cfg.ampConf))}
+    '';
 
     # === konea: runs as daemon with -start ===
     systemd.services.konea = {

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -43,6 +43,22 @@ let
   # Path to kace binaries
   kaceBinDir = "${cfg.package}/opt/quest/kace/bin";
 
+  # Wrapper for the 10-min konea checker. AMPWatchDog -k revives konea (it
+  # detects systemd and does `systemctl start konea`), but it does NOT restart
+  # KSchedulerConsole, which also dies on an SMA agent-reset (RESETAGENT stops
+  # both, so Restart=always never fires). konea has no scheduler code of its
+  # own, so without KSchedulerConsole scheduled inventory/scripts silently stop.
+  # KACE's own AMPctl starts both konea and KSchedulerConsole together, so we
+  # mirror that here.
+  koneaCheckerScript = pkgs.writeShellScript "kace-konea-checker" ''
+    set +e
+    ${kaceBinDir}/AMPWatchDog -k
+    if ! ${pkgs.systemd}/bin/systemctl is-active --quiet kschedulerconsole.service; then
+      echo "konea-checker: KSchedulerConsole not running, starting it"
+      ${pkgs.systemd}/bin/systemctl start kschedulerconsole.service
+    fi
+  '';
+
   # Script that re-applies NixOS-managed keys to amp.conf.
   # Runs after a delay so it fires after KBOX pushes its config on connect,
   # which would otherwise clobber keys we set at activation time.
@@ -126,7 +142,7 @@ in
     enableWatchdog = mkOption {
       type = types.bool;
       default = false;
-      description = "Enable AMPWatchDog via systemd timers (replaces the cron one-shots KACE ships: every 6h watchdog + every 10 min konea checker).";
+      description = "Enable AMPWatchDog via systemd timers (replaces the cron one-shots KACE ships: every 6h watchdog + every 10 min konea checker). The 10 min checker also restarts KSchedulerConsole, which AMPWatchDog -k does not cover.";
     };
   };
 
@@ -312,7 +328,7 @@ in
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
         Environment = kaceEnv;
-        ExecStart = "${kaceBinDir}/AMPWatchDog -k";
+        ExecStart = koneaCheckerScript;
         StandardOutput = "journal";
         StandardError = "journal";
       };

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -57,35 +57,6 @@ let
       fi
     '') ({ name = cfg.name; } // cfg.ampConf))}
   '';
-
-  # Helper: direct foreground execution (preferred on NixOS)
-  mkKaceServiceSimple = name: desc: extraOpts:
-    let
-      bin = "${kaceBinDir}/${name}";
-    in
-    {
-      description = desc;
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = bin;
-        KillSignal = "SIGTERM";
-        KillMode = "control-group";
-        TimeoutStartSec = 120;
-        TimeoutStopSec = 30;
-        Restart = "on-failure";
-        RestartSec = 5;
-        User = cfg.user;
-        Group = cfg.group;
-        WorkingDirectory = cfg.dataDir;
-        Environment = kaceEnv;
-        StandardOutput = "journal";
-        StandardError  = "journal";
-      };
-    } // extraOpts;
 in
 {
   options.services.kace-ampagent = {
@@ -155,7 +126,7 @@ in
     enableWatchdog = mkOption {
       type = types.bool;
       default = false;
-      description = "Enable standalone AMPWatchDog as systemd service (replaces cron).";
+      description = "Enable AMPWatchDog via systemd timers (replaces the cron one-shots KACE ships: every 6h watchdog + every 10 min konea checker).";
     };
   };
 
@@ -294,33 +265,54 @@ in
     };
 
     # === Optional AMPWatchDog ===
-    systemd.services.ampwatchdog = mkIf cfg.enableWatchdog (mkKaceServiceSimple "AMPWatchDog" "KACE Watchdog Service" {
-      after = [ "konea.service" ];
-      requires = [ "konea.service" ];
-    });
-
-    # === Optional timer ===
-    systemd.timers.konea-checker = mkIf cfg.enableWatchdog {
-      description = "Periodic KACE health check";
+    # KACE ships AMPWatchDog as periodic cron one-shots (see AMPWatchDogCrontab
+    # and KoneaCheckerCrontab in the package), so we model it as systemd timers,
+    # NOT a long-running service. A watchdog must not depend on konea.service --
+    # if it did, it would be stopped whenever konea is stopped (e.g. by an SMA
+    # agent-reset), which is exactly the failure it exists to recover from.
+    systemd.timers.ampwatchdog = mkIf cfg.enableWatchdog {
+      description = "AMPWatchDog periodic health check";
       wantedBy = [ "timers.target" ];
       timerConfig = {
-        OnBootSec = "1min";
-        OnUnitActiveSec = "5min";
+        OnCalendar = "*-*-* 03,09,15,21:05:00"; # matches AMPWatchDogCrontab (every 6h)
+        AccuracySec = "1m";
+        Persistent = true;
+      };
+    };
+
+    systemd.services.ampwatchdog = mkIf cfg.enableWatchdog {
+      description = "AMPWatchDog KACE watchdog (one-shot per timer tick)";
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        Environment = kaceEnv;
+        ExecStart = [ "${kaceBinDir}/AMPWatchDog" ];
+        StandardOutput = "journal";
+        StandardError = "journal";
+      };
+    };
+
+    systemd.timers.konea-checker = mkIf cfg.enableWatchdog {
+      description = "Periodic KACE konea health check";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "*-*-* *:00,10,20,30,40,50:00"; # matches KoneaCheckerCrontab (every 10 min)
         AccuracySec = "1m";
         Persistent = true;
       };
     };
 
     systemd.services.konea-checker = mkIf cfg.enableWatchdog {
-      description = "KACE Konea health check (once per timer tick)";
-      after = [ "konea.service" ];
-      requires = [ "konea.service" ];
+      description = "KACE konea health check (one-shot per timer tick)";
       serviceConfig = {
         Type = "oneshot";
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
-        ExecStart = "${cfg.package}/opt/quest/kace/bin/AMPHealthCheck";
+        Environment = kaceEnv;
+        ExecStart = [ "${kaceBinDir}/AMPWatchDog" "-k" ];
         StandardOutput = "journal";
         StandardError = "journal";
       };

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -32,6 +32,21 @@ let
   # Path to kace binaries
   kaceBinDir = "${cfg.package}/opt/quest/kace/bin";
 
+  # Script that re-applies NixOS-managed keys to amp.conf.
+  # Runs after a delay so it fires after KBOX pushes its config on connect,
+  # which would otherwise clobber keys we set at activation time.
+  ampConfPatchScript = pkgs.writeShellScript "kace-ampconf-patch" ''
+    sleep 30
+    CONF="${cfg.dataDir}/amp.conf"
+    ${concatStringsSep "\n" (mapAttrsToList (k: v: ''
+      if ${pkgs.gnugrep}/bin/grep -q "^${k}=" "$CONF"; then
+        ${pkgs.gnused}/bin/sed -i 's|^${k}=.*|${k}=${v}|' "$CONF"
+      else
+        printf '%s\n' '${k}=${v}' >> "$CONF"
+      fi
+    '') ({ name = cfg.name; } // cfg.ampConf))}
+  '';
+
   # Helper: direct foreground execution (preferred on NixOS)
   mkKaceServiceSimple = name: desc: extraOpts:
     let
@@ -155,16 +170,18 @@ in
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
         "d ${cfg.logDir} 0750 ${cfg.user} ${cfg.group} - -"
-        # hostname is not at a standard FHS path on NixOS; inventory scripts
-        # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
-        "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
-        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
-        "L+ /usr/sbin/dmidecode - - - - /run/current-system/sw/bin/dmidecode"
+        # hostname and dmidecode are not at standard FHS paths on NixOS.
+        # Point symlinks directly to the nix store path (NOT /run/current-system/sw/bin)
+        # so they are never dangling regardless of environment.systemPackages.
+        "L+ /usr/local/bin/hostname - - - - ${pkgs.inetutils}/bin/hostname"
+        "L+ /usr/sbin/dmidecode - - - - ${pkgs.dmidecode}/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 
-    # === Write NixOS-managed keys into amp.conf ===
-    # Merges host= and any ampConf entries into the live amp.conf on every
-    # nixos-rebuild switch, preserving all other keys pushed down by KBOX.
+    # === Write NixOS-managed keys into amp.conf at activation time ===
+    # Handles initial setup and ensures host= is always correct.
+    # Note: KBOX pushes a fresh amp.conf on every konea connection, which
+    # clobbers keys like name=. The ExecStartPost on konea re-applies them
+    # 30 s after start (after the KBOX push settles).
     system.activationScripts.kace-ampconf = ''
       mkdir -p "${cfg.dataDir}"
       CONF="${cfg.dataDir}/amp.conf"
@@ -187,6 +204,10 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.bash}/bin/bash -c 'PATH=${finalPath} exec ${kaceBinDir}/konea'";
+        # Re-apply name= (and any ampConf keys) after KBOX pushes its config.
+        # KBOX overwrites amp.conf shortly after konea connects; 30 s is enough
+        # for that push to complete before we write our keys back.
+        ExecStartPost = ampConfPatchScript;
         KillSignal = "SIGTERM";
         KillMode = "control-group";
         TimeoutStartSec = 120;

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -235,7 +235,13 @@ in
         KillMode = "control-group";
         TimeoutStartSec = 120;
         TimeoutStopSec = 30;
-        Restart = "on-failure";
+        # "always", not "on-failure": the SMA's agent-reset tells konea to shut
+        # down, and konea exits 0. on-failure ignores a clean exit, so the agent
+        # stays dead until the next reboot with nothing appearing to be wrong.
+        # Observed 2026-08-07: a reset at 08:50:35 took konea and
+        # KSchedulerConsole down and neither returned for hours -- no scheduled
+        # or forced inventory can run in that state.
+        Restart = "always";
         RestartSec = 5;
         User = cfg.user;
         Group = cfg.group;
@@ -261,7 +267,10 @@ in
         KillMode = "control-group";
         TimeoutStartSec = 120;
         TimeoutStopSec = 30;
-        Restart = "on-failure";
+        # Same clean-exit-on-reset problem as konea above. Without this the
+        # scheduler stays dead after a reset, so even the periodic inventory
+        # stops -- the failure is silent because nothing ever reports failed.
+        Restart = "always";
         RestartSec = 5;
         User = cfg.user;
         Group = cfg.group;

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -14,6 +14,9 @@ let
     pkgs.gnused       # sed
     pkgs.findutils    # find, xargs
     pkgs.inetutils    # hostname - needed by inventory scripts
+    pkgs.systemd      # systemctl - needed for startup programs inventory
+    pkgs.pciutils     # lspci - needed for audio/video hardware inventory
+    pkgs.networkmanager # nmcli - needed for DHCP/network inventory
   ];
 
   # Environment: build systemd-friendly env list
@@ -145,6 +148,9 @@ in
       };
     };
 
+    # dmidecode is hardcoded to /usr/sbin/dmidecode by KInventory; ensure it is installed.
+    environment.systemPackages = [ pkgs.dmidecode ];
+
     systemd.tmpfiles.rules =
       [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
@@ -152,6 +158,8 @@ in
         # hostname is not at a standard FHS path on NixOS; inventory scripts
         # that reset PATH to /bin:/usr/bin:/usr/local/bin need it here.
         "L+ /usr/local/bin/hostname - - - - /run/current-system/sw/bin/hostname"
+        # dmidecode is hardcoded to /usr/sbin/dmidecode in KInventory (not on PATH).
+        "L+ /usr/sbin/dmidecode - - - - /run/current-system/sw/bin/dmidecode"
       ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
 
     # === Write NixOS-managed keys into amp.conf ===


### PR DESCRIPTION
Closes #23. 

Further fixes for correctly passing the local hostname and for restarting the local kace-related services should they stop for any reason.