### PR TITLE
Add optional tarball URL for pure builds and bump agent to 15.1.45 - …

### DIFF
--- a/.github/workflows/build-kace-ampagent.yml
+++ b/.github/workflows/build-kace-ampagent.yml
@@ -8,6 +8,15 @@ on:
         branches:
             - main
 
+env:
+    # Repository secret holding a publicly reachable agent tarball URL, e.g.
+    # https://github.com/<owner>/resources/releases/download/15.1.45/ampagent-15.1.45.ubuntu.64.tar.gz
+    # When set, builds fetch the tarball via fetchurl (no manual `nix store add-file`).
+    # When unset, builds fall back to requireFile and fail unless the tarball is
+    # already in the Nix store.
+    # Note: GitHub does not expose secrets to pull requests from forks.
+    KACE_TARBALL_URL: ${{ secrets.KACE_TARBALL_URL }}
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -22,11 +31,19 @@ jobs:
                   extra_config: |
                       experimental-features = nix-command flakes
 
+            - name: Check tarball source availability
+              run: |
+                  if [ -z "$KACE_TARBALL_URL" ]; then
+                      echo "::warning::KACE_TARBALL_URL is not set. Builds will use requireFile and FAIL unless the tarball is present in the Nix store."
+                  fi
+
             - name: Build kace-ampagent package
               run: |
                   pwd
                   ls -la
-                  nix build .#kace-ampagent --print-build-logs
+                  # No --print-build-logs: fetchurl echoes the tarball URL into the
+                  # build log, which is weaker-masked on redirect/re-encode.
+                  nix build --impure .#kace-ampagent-env
 
             - name: Validate NixOS module
               run: |
@@ -51,6 +68,10 @@ jobs:
                             boot.loader.grub.enable = lib.mkForce false;
                             networking.hostName = "test-kace-ampagent-module";
                             services.kace-ampagent.enable = true;
+                            services.kace-ampagent.host = "kbox.invalid";
+                            services.kace-ampagent.packageUrl =
+                              let v = builtins.getEnv "KACE_TARBALL_URL";
+                              in if v == "" then null else v;
                           })
                         ];
                       };
@@ -59,4 +80,6 @@ jobs:
                   EOF
 
                   # Build from repository root pointing into the temporary flake so relative "path:.." resolves correctly
-                  nix build ./temp-nixos-test#nixosConfigurations.test.config.system.build.toplevel --print-build-logs
+                  # No --print-build-logs here either: this step also fetchurl's the
+                  # tarball via packageUrl, and failure logs could echo the URL.
+                  nix build --impure ./temp-nixos-test#nixosConfigurations.test.config.system.build.toplevel

--- a/.github/workflows/build-kace-ampagent.yml
+++ b/.github/workflows/build-kace-ampagent.yml
@@ -49,13 +49,20 @@ jobs:
               run: |
                   pwd
                   ls -la
-                  mkdir -p temp-nixos-test
+                  # Create the test flake OUTSIDE the repository checkout: for a
+                  # flake path inside a git worktree, Nix copies only git-tracked
+                  # files to the store, so an untracked temp dir inside the repo
+                  # vanishes from the store copy and resolution fails with
+                  # ".../temp-nixos-test/flake.nix does not exist".
+                  mkdir -p ../temp-nixos-test
 
-                  cat > temp-nixos-test/flake.nix <<'EOF'
+                  cat > ../temp-nixos-test/flake.nix <<'EOF'
                   { description = "Temporary flake for NixOS module validation";
                     inputs = {
                       nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-                      kaceAgent.url = "path:.."; # parent of temp-nixos-test is repo root with your main flake
+                      # Placeholder: rewritten to the absolute checkout path below
+                      # (a bare "path:.." input fails to resolve as a store path).
+                      kaceAgent.url = "path:@REPO@";
                     };
                     outputs = { self, nixpkgs, kaceAgent, ... }: {
                       nixosConfigurations.test = nixpkgs.lib.nixosSystem {
@@ -66,7 +73,10 @@ jobs:
                           ({ config, lib, pkgs, ... }: {
                             boot.loader.systemd-boot.enable = lib.mkForce false;
                             boot.loader.grub.enable = lib.mkForce false;
+                            fileSystems."/" = { device = "/dev/null"; fsType = "ext4"; };
                             networking.hostName = "test-kace-ampagent-module";
+                            nixpkgs.config.allowUnfree = true; # kace-ampagent is licenses.unfree
+                            system.stateVersion = "25.11";
                             services.kace-ampagent.enable = true;
                             services.kace-ampagent.host = "kbox.invalid";
                             services.kace-ampagent.packageUrl =
@@ -78,8 +88,9 @@ jobs:
                     };
                   }
                   EOF
+                  sed -i "s|@REPO@|$GITHUB_WORKSPACE|" ../temp-nixos-test/flake.nix
 
-                  # Build from repository root pointing into the temporary flake so relative "path:.." resolves correctly
-                  # No --print-build-logs here either: this step also fetchurl's the
-                  # tarball via packageUrl, and failure logs could echo the URL.
-                  nix build --impure ./temp-nixos-test#nixosConfigurations.test.config.system.build.toplevel
+                  # Build the sibling temp flake. No --print-build-logs: this step
+                  # also fetchurl's the tarball via packageUrl, and failure logs
+                  # could echo the URL.
+                  nix build --impure ../temp-nixos-test#nixosConfigurations.test.config.system.build.toplevel

--- a/README.md
+++ b/README.md
@@ -8,14 +8,28 @@ This project provides a Nix package and NixOS module for the Quest KACE AMP Agen
 
 ## Providing the Agent Tarball
 
-The `kace-ampagent` Nix package requires the official generic Linux agent tarball (e.g., `ampagent-15.0.54.ubuntu.64.tar.gz`). This file is not included in the repository due to licensing and distribution restrictions.
+The `kace-ampagent` Nix package requires the official Quest KACE SMA generic Linux agent tarball (currently `ampagent-15.1.45.ubuntu.64.tar.gz`; see `version` in `pkgs/kace-ampagent/default.nix`). This file is not included in the repository due to licensing and distribution restrictions. There are two ways to provide it.
 
-You must provide this file yourself. The `pkgs/kace-ampagent/default.nix` uses `requireFile` to locate it based on its filename and SHA256 hash.
+### Option A - Fetch by URL (pure build, recommended)
 
-Follow these steps to make the tarball available to Nix:
+Set `services.kace-ampagent.packageUrl` (or pass `url` directly to the package via `pkgs.kace-ampagent.override { url = "..."; }`). Nix downloads the tarball with `fetchurl` and verifies it against the SHA256 pinned in `pkgs/kace-ampagent/default.nix`:
+
+```nix
+services.kace-ampagent = {
+  enable = true;
+  host = "kbox.example.com";
+  packageUrl = "https://your-server.example.com/ampagent-15.1.45.ubuntu.64.tar.gz";
+};
+```
+
+- Any publicly reachable HTTP(S) location works (web server, GitHub release, internal mirror); the downloaded bytes must match the pinned hash or the build fails.
+- Do **not** put credentials or tokens in the URL (including query strings): URLs can surface in store paths and logs.
+- This repository's GitHub Actions workflow fetches the tarball using the `KACE_TARBALL_URL` repository secret (Settings -> Secrets and variables -> Actions).
+
+### Option B - Manual store import (`requireFile`)
 
 1.  **Download the Agent Tarball:**
-    Obtain the `ampagent-<version>.ubuntu.64.tar.gz` file from your KACE SMA portal. The exact filename and version are specified within `pkgs/kace-ampagent/default.nix`.
+    Obtain the `ampagent-<version>.ubuntu.64.tar.gz` file from your KACE SMA portal. The exact filename and version are specified within `pkgs/kace-ampagent/default.nix`. See also the Quest KB: https://support.quest.com/kb/4272341/how-to-find-and-install-the-generic-linux-agent-for-sma
 
 2.  **Verify SHA256 Hash (Recommended):**
     The `default.nix` file contains a specific SHA256 hash for the expected tarball. If your downloaded file has a different hash, the build will fail. You can compute the hash of your file using:
@@ -51,42 +65,72 @@ inputs = {
 imports = [ kace-ampagent.nixosModules.kace-ampagent ];
 ```
 
-3. **Enable and configure the agent** (see Module Options below). Do **not** set `services.kace-ampagent.package` unless you have a specific reason: the default package comes from the overlay and is built with the same nixpkgs as the rest of your system, which avoids glibc mismatches and keeps your config independent of `inputs.kace-ampagent` in scope.
+3. **Allow unfree packages.** The agent is proprietary (`licenses.unfree`), so your host configuration must set:
+
+```nix
+nixpkgs.config.allowUnfree = true;
+```
+
+4. **Enable and configure the agent** (see Module Options below). Do **not** set `services.kace-ampagent.package` unless you have a specific reason: the default package comes from the overlay and is built with the same nixpkgs as the rest of your system, which avoids glibc mismatches and keeps your config independent of `inputs.kace-ampagent` in scope.
 
 ```nix
 services.kace-ampagent = {
   enable = true;
   host = "kbox.example.com";
-  # ampConf = { ... };  # optional
+  # Pure build: fetch the tarball from a URL instead of `nix store add-file`.
+  # The URL can also come from a sops-decoded file or any other source at eval time.
+  packageUrl = "https://github.com/your-org/resources/releases/download/15.1.45/ampagent-15.1.45.ubuntu.64.tar.gz";
 };
 ```
 
+If you omit `packageUrl`, provide the tarball manually via Option B above.
+
 You do not need to reference `kace-ampagent` in your flake `outputs` or `specialArgs`; the module is self-contained once imported.
+
+### Optional extras
+
+```nix
+services.kace-ampagent = {
+  enable = true;
+  host = "kbox.example.com";
+  name = "web01";               # defaults to networking.hostName
+  ampConf = { org = "Default"; };
+  environment = { KACE_HTTPS = "true"; };
+  enableWatchdog = true;        # 6h watchdog + 10min konea/scheduler checker timers
+  linkOptPath = true;           # /opt/quest/kace symlink (default)
+};
+```
 
 ## Local Build
 
-To build the package or test the flake locally (after providing the tarball as described above):
+To build the package or test the flake locally:
 
 ```bash
+# Manual tarball mode (requires Option B store import first)
 nix build .#kace-ampagent
+
+# URL mode (pure): reads KACE_TARBALL_URL from the environment
+KACE_TARBALL_URL="https://your-server.example.com/ampagent-15.1.45.ubuntu.64.tar.gz" \
+  nix build --impure .#kace-ampagent-env
 ```
+
+The `kace-ampagent-env` output falls back to `requireFile` behavior when the variable is unset or when built without `--impure`.
 
 ## Module Options
 
--   `services.kace-ampagent.enable`: Enable the KACE AMP Agent (boolean, default `false`). When enabled, the following systemd services are started:
-    -   `kace-ampagent-initial-config`: One-time service that runs `konea -url` and `konea -enable` to enroll the agent with the server
-    -   `kace-ampagent-setup`: Creates the `amp.conf` configuration file with the host and optional settings
-    -   `konea`: Main KACE agent service that runs `konea -start` as a daemon
-    -   `kschedulerconsole`: Scheduler console service that starts after konea
-    -   `ampwatchdog.timer` + `ampwatchdog.service` (optional): AMPWatchDog watchdog one-shot every 6 h when `enableWatchdog = true` (matches the shipped `AMPWatchDogCrontab`)
+-   `services.kace-ampagent.enable`: Enable the KACE AMP Agent (boolean, default `false`). When enabled, the module creates `konea.service` (main daemon), `kschedulerconsole.service`, and - with `enableWatchdog = true` - the watchdog timers described below. `amp.conf` is managed by an activation script plus a post-start patch script, not by separate oneshot services.
 -   `services.kace-ampagent.package`: The Nix package providing the KACE agent binaries (package, default: `pkgs.kace-ampagent` from the overlay). Leave unset so the module builds the package with your system's nixpkgs; override only if you need a different source.
+-   `services.kace-ampagent.packageUrl`: Optional URL to fetch the agent tarball for pure builds (string or null, default `null`). When set, the module builds the package from that URL (`fetchurl`, verified against the pinned SHA256); when null, the package uses `requireFile` and expects the tarball in your store.
+-   `services.kace-ampagent.user`: User to run KACE services (string, default `"root"`).
+-   `services.kace-ampagent.group`: Group to run KACE services (string, default `"root"`).
 -   `services.kace-ampagent.dataDir`: The directory where the agent stores its data (string, default `/var/quest/kace`).
 -   `services.kace-ampagent.logDir`: The directory where the agent stores its logs (string, default `/var/log/quest/kace`).
 -   `services.kace-ampagent.environment`: An attribute set of extra environment variables for the agent (attrset, default `{}`).
 -   `services.kace-ampagent.linkOptPath`: Create a `/opt/quest/kace` symlink pointing to the package content for compatibility (boolean, default `true`).
 -   `services.kace-ampagent.host`: The KACE SMA host (string, required). Written to `amp.conf` as `host=`.
+-   `services.kace-ampagent.name`: Machine name reported to KBOX (string, default: `networking.hostName`). Written to `amp.conf` as `name=` and re-applied after each konea start (see Service Behavior).
 -   `services.kace-ampagent.ampConf`: An attribute set of additional key-value pairs for `amp.conf` (attrset, default `{}`).
--   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset. The 10 min `konea-checker` additionally restarts `KSchedulerConsole` if it is not running, because `AMPWatchDog -k` only revives konea — leaving the scheduler (which drives scheduled inventory/scripts) dead after a reset.
+-   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset. The 10 min `konea-checker` additionally restarts `KSchedulerConsole` if it is not running, because `AMPWatchDog -k` only revives konea - leaving the scheduler (which drives scheduled inventory/scripts) dead after a reset.
 
 ### Example
 
@@ -99,28 +143,29 @@ services.kace-ampagent = {
     org = "Default";
     # Other settings like CERT_VALIDATION, etc.
   };
-  enableWatchdog = true; # Optional: enables AMPWatchDog service
+  enableWatchdog = true; # Optional: watchdog + konea-checker timers
 };
 ```
 
-## Service Behavior and Order
+## Service Behavior
 
-When the module is enabled, the following systemd services are created and run in order:
+When the module is enabled:
 
-1. **`kace-ampagent-setup.service`** (oneshot): Creates `/var/quest/kace/amp.conf` with `host=` and any `ampConf` entries
+1. **Activation (`system.activationScripts.kace-ampconf`)**: At system activation, the module ensures `/var/quest/kace/amp.conf` exists and upserts `host=`, `name=`, and every `ampConf` key (sed replace-in-place if the key exists, append otherwise).
 
-2. **`kace-ampagent-initial-config.service`** (oneshot): Runs once to enroll the agent:
-   - Runs `konea -url <host>` to configure the server URL
-   - Runs `konea -enable` to enroll the agent and download kbot scripts
-   - Creates `/var/quest/kace/.initial-config-done` marker file to prevent re-running
+2. **`konea.service`** (simple daemon): Runs konea from the package with the module's PATH (coreutils, bash, psmisc, grep, sed, awk, find, hostname, ps/free, lscpu, ip, systemctl, lspci, nmcli - konea's spawn chain inherits this PATH, and inventory tools missing from it cause silently discarded inventory documents). After start, an `ExecStartPost` script waits 30 seconds and re-applies `name=` and all `ampConf` keys: KBOX pushes a fresh `amp.conf` down shortly after konea connects, which would otherwise clobber locally-set keys. Uses `Restart = always` - the SMA's agent-reset makes konea exit cleanly (exit 0), which `Restart = on-failure` would ignore, leaving the agent dead until reboot.
 
-3. **`konea.service`** (simple): Runs `konea -start` as a daemon to connect to the KACE SMA
+3. **`kschedulerconsole.service`** (simple): Starts 10 s after konea (`requires konea.service`). Also uses `Restart = always` for the same clean-exit-on-reset reason.
 
-4. **`kschedulerconsole.service`** (simple): Runs `KSchedulerConsole` (depends on konea)
+4. **Optional watchdog** (`enableWatchdog = true`) - two systemd timers modeled after the cron one-shots shipped in the package. They deliberately do **not** depend on `konea.service`, so they still run after an SMA agent-reset stops konea:
+   - **`ampwatchdog.timer` / `ampwatchdog.service`**: runs `AMPWatchDog` every 6 h (`*-*-* 03,09,15,21:05:00`, matching `AMPWatchDogCrontab`)
+   - **`konea-checker.timer` / `konea-checker.service`**: runs every 10 min (`*:00,10,20,30,40,50:00`, matching `KoneaCheckerCrontab`) a wrapper that invokes `AMPWatchDog -k` (revives konea) and starts `kschedulerconsole.service` if it is down - `AMPWatchDog -k` only revives konea, but RESETAGENT stops both processes, so without this scheduled inventory/scripts would silently stop after a reset.
 
-5. **`ampwatchdog.timer`** and **`ampwatchdog.service`** (oneshot, optional): Runs `AMPWatchDog` every 6 h when `enableWatchdog = true` — independently of `konea.service`
+### FHS compatibility layer
 
-6. **`konea-checker.timer`** and **`konea-checker.service`** (oneshot, optional): Runs `AMPWatchDog -k` every 10 min when `enableWatchdog = true` — independently of `konea.service`. Also starts `KSchedulerConsole` if it is down (covers the SMA agent-reset case where both stop cleanly and `Restart=always` never fires).
+The module creates tmpfiles symlinks so the prebuilt Ubuntu binaries find their tools on NixOS: `hostname` at `/usr/local/bin`, `/usr/bin` and `/bin` (from inetutils; konea hardcodes `PATH=/usr/bin:/bin`), `/usr/sbin/dmidecode`, `/usr/bin/{lspci,systemctl,nmcli,lscpu,ip,lsblk}`, `/bin/bash`, plus dmidecode added to `environment.systemPackages`.
+
+Known limitation: KACE `INSTALLED_SOFTWARE` inventory stays empty because `rpm`/`dpkg-query` do not exist on NixOS ("Only RPM and Debian package systems currently supported!"). Addressing it requires a server-side KACE Custom Inventory Rule.
 
 ## Using the Agent Manually
 
@@ -153,12 +198,10 @@ When running `konea` commands manually (outside of systemd):
 
 -   The KACE agent expects its files under `/opt/quest/kace`. The module creates a symlink to the package content at `/opt/quest/kace` by default (`services.kace-ampagent.linkOptPath = true;`).
 
--   **Initial enrollment is automatic**: When you first enable the module, `konea -enable` runs automatically during the initial configuration. This enrollment connects the agent to your KACE SMA and downloads kbot scripts. You do not need to run this manually.
+-   **Enrollment happens through normal konea operation**: once `host` is set in `amp.conf` (activation script) and konea can reach the SMA, the agent enrolls itself. If it does not connect, check `journalctl -u konea.service` for reachability or certificate errors.
 
 -   When running `konea` or `runkbot` manually, ensure PATH includes `killall` (psmisc) and `true` (coreutils). The systemd services automatically add these to PATH; for manual runs, use `sudo systemctl start konea` or add them manually.
 
 -   The agent logs to `/var/log/quest/kace/`. You can view logs with `journalctl -u konea.service`.
 
--   The `amp.conf` file is created at `/var/quest/kace/amp.conf` with the host and any additional `ampConf` settings.
-
--   Depending on your KACE SMA configuration and agent version, you may need to perform a manual enrollment step after the services start to fully configure the agent. The initial configuration service handles this automatically via `konea -enable`.
+-   The `amp.conf` file lives at `/var/quest/kace/amp.conf`. It is written at system activation (`host`, `name`, `ampConf` keys) and re-patched 30 s after each konea start (`name`, `ampConf` keys), because KBOX pushes its own copy of `amp.conf` when konea connects.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,363 @@
+# kace-ampagent - Agent Documentation
+
+Factual documentation for AI agents and developers working on this repository.
+Everything here is derived from source code, README.md, git history, or public
+NixOS/Quest KACE references. Sections are labeled by verification source.
+This file is ASCII-only by design (some model tokenizers choke on Unicode box
+drawing characters).
+
+Repository: https://github.com/kd2flz/kace-ampagent (remote `origin`)
+License: unfree (Quest proprietary). Platforms: x86_64-linux only.
+Maintainer: David Rhoads.
+
+---
+
+## 1. Repository Layout
+
+```
+kace-ampagent/
+|-- flake.nix                          # Flake: overlay + packages + nixosModule
+|-- modules/services/kace-ampagent.nix # NixOS module
+|-- pkgs/kace-ampagent/default.nix     # Package derivation
+|-- README.md                          # User-facing docs
+|-- agents.md                          # This file
+`-- .github/workflows/build-kace-ampagent.yml  # CI
+```
+
+Branches: `main`, `dev`, `call-konea-directly`. Development happens on `dev`
+and is merged to `main` via PRs (merge commits reference PRs from forks such
+as kd2hbv/dev).
+
+---
+
+## 2. Flake Interface [code: flake.nix]
+
+- Input: `nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11"`.
+- Systems: `[ "x86_64-linux" ]`.
+- `overlays.default`: adds `pkgs.kace-ampagent` via `final.callPackage ./pkgs/kace-ampagent { }`.
+- `packages.<system>.default` / `.kace-ampagent`.
+- `packages.<system>.kace-ampagent-env`: env-aware variant. Reads
+  KACE_TARBALL_URL via builtins.getEnv wrapped in tryEval; when the variable
+  is set AND evaluation is impure (`--impure`), it builds with
+  `url = $KACE_TARBALL_URL` (fetchurl path). Otherwise it is identical to
+  kace-ampagent (requireFile). Intended for CI.
+- `nixosModules.kace-ampagent`: imports the module file and injects
+  `nixpkgs.overlays = [ self.overlays.default ]`, so `pkgs.kace-ampagent`
+  resolves inside consumer configs without extra wiring.
+- The flake's own pkgs import sets `config.allowUnfree = true`.
+
+---
+
+## 3. Package [code: pkgs/kace-ampagent/default.nix]
+
+Current version: **15.1.45** (bumped from 15.0.54 on 2026-08-23).
+Tarball name pattern: `ampagent-<version>.ubuntu.64.tar.gz`.
+
+### Source acquisition (two mutually exclusive paths)
+
+The derivation accepts an optional `url ? null` parameter:
+
+- `url != null`: source = `fetchurl { inherit url; sha256 = ...; }`.
+  Enables pure builds; no manual store step.
+- `url == null` (default): source = `requireFile { name; sha256; message; }`.
+  User must download the tarball and run
+  `nix store add-file ./ampagent-<version>.ubuntu.64.tar.gz`.
+
+SHA256 (both paths): `sha256-nkCcTIKybOJCytZzYXrrkjW6KK3pPa02z/oBLEW0hB0=`
+
+Known-good URL used for testing:
+`https://github.com/kd2flz/resources/releases/download/15.1.45/ampagent-15.1.45.ubuntu.64.tar.gz`
+
+Official agent download procedure (Quest KB):
+https://support.quest.com/kb/4272341/how-to-find-and-install-the-generic-linux-agent-for-sma
+
+### Build steps (installPhase)
+
+- `dontUnpack = true`; manual tar extraction into a temp dir.
+- Requires `opt/` at archive top level; copies it to `$out/opt/`. Errors out
+  with an archive listing if missing.
+- Installs a minimal LSB `init-functions` stub at
+  `$out/opt/quest/kace/lib/lsb/init-functions` (NixOS has no /lib/lsb) and
+  rewrites `/lib/lsb/init-functions` references in bin/* scripts to point at it.
+- Injects psmisc/coreutils into PATH of `AMPctl` and `AMPAgentBootup`.
+- Rewrites hardcoded `/bin/true` to `true` (PATH lookup) across bin/*.
+- Removes `2> /dev/null` stderr suppression in `AMPctl`/`AMPAgentBootup` so
+  startup errors reach journalctl.
+- Creates `$out/bin` symlinks: AMPctl, AMPAgentBootup, konea.
+
+### Dependencies
+
+nativeBuildInputs: autoPatchelfHook, makeWrapper.
+buildInputs: stdenv.cc.cc.lib, stdenv.cc.libc (glibc), psmisc, coreutils.
+
+Output layout:
+
+```
+$out/bin/{AMPctl,AMPAgentBootup,konea} -> ../opt/quest/kace/bin/*
+$out/opt/quest/kace/bin/               # konea, KSchedulerConsole, AMPWatchDog,
+                                       # AMPHealthCheck, runkbot, AMPctl, ...
+$out/opt/quest/kace/lib/lsb/init-functions
+```
+
+---
+
+## 4. NixOS Module [code: modules/services/kace-ampagent.nix]
+
+Namespace: `services.kace-ampagent.*`. Everything below only applies when
+`enable = true` (config block wrapped in `mkIf cfg.enable`).
+
+### Options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| enable | bool | false | mkEnableOption |
+| package | package | pkgs.kace-ampagent | From overlay |
+| packageUrl | nullOr str | null | NEW 2026-08-23: when non-null, module uses pkgs.kace-ampagent.override { url = cfg.packageUrl; } instead of cfg.package |
+| user | str | "root" | Service user |
+| group | str | "root" | Service group |
+| dataDir | str | "/var/quest/kace" | amp.conf lives here |
+| logDir | str | "/var/log/quest/kace" | Log directory |
+| host | str | (no default) | Written to amp.conf as host= |
+| name | str | config.networking.hostName | Machine name reported to KBOX (name= key) |
+| ampConf | attrsOf str | {} | Extra key=value lines for amp.conf |
+| environment | attrsOf str | {} | Extra env vars; PATH gets special handling below |
+| linkOptPath | bool | true | tmpfiles symlink /opt/quest/kace -> package |
+| enableWatchdog | bool | false | Enables the two timers described below |
+
+Effective package binding:
+
+```
+kacePackage = if cfg.packageUrl != null
+              then pkgs.kace-ampagent.override { url = cfg.packageUrl; }
+              else cfg.package;
+```
+
+All binary paths use `${kacePackage}/opt/quest/kace/bin`.
+
+### PATH construction (critical; rationale from code comments)
+
+`kacePath = lib.makeBinPath [...]` over 15 packages: coreutils, bash, psmisc,
+gnugrep, gnused, gawk, findutils, inetutils, procps, util-linux, iproute2,
+systemd, pciutils, networkmanager.
+
+Why so many: konea does not sanitise PATH; its spawn chain (konea -> KPlugins
+-> runkbot -> KBoxClient -> KInventory) inherits it. Missing lscpu produced
+~4.5KB inventory documents reporting 0 CPUs which the SMA silently discards
+(HTTP 200 with empty body; only symptom: Last Inventory never advances). With
+the tools present, inventories are ~33.8KB. Verified in-repo 2026-08-14. Tools
+must be on THIS PATH; /usr/bin FHS symlinks alone do not work because the
+spawn PATH has no /usr/bin.
+
+If the user sets `environment.PATH`, it is appended after kacePath. All other
+environment attrs become Environment= entries on every service.
+
+### amp.conf management (two mechanisms)
+
+1. Activation script `system.activationScripts.kace-ampconf` (runs at system
+   activation): ensures dataDir exists and amp.conf exists, then upserts keys:
+   `host = cfg.host`, `name = cfg.name`, plus every cfg.ampConf pair.
+   Upsert = sed replace-in-place if key exists, else append line.
+2. ExecStartPost on konea.service runs `ampConfPatchScript`: sleeps 30s, then
+   re-applies `name = cfg.name` plus all cfg.ampConf keys with the same upsert
+   logic. Reason: KBOX pushes a fresh amp.conf down shortly after konea
+   connects, clobbering locally-set keys; 30s lets that push settle first.
+   Note asymmetry: host= is written at activation only; name=/ampConf are
+   re-applied post-start.
+
+### FHS compatibility layer (tmpfiles.rules)
+
+Directories: dataDir and logDir, mode 0750 owner cfg.user:cfg.group.
+
+Symlinks (L+ rules):
+- /usr/local/bin/hostname, /usr/bin/hostname, /bin/hostname ->
+  ${pkgs.inetutils}/bin/hostname (konea hardcodes PATH=/usr/bin:/bin)
+- /usr/sbin/dmidecode -> ${pkgs.dmidecode}/bin/dmidecode (hardcoded path in
+  KInventory)
+- /usr/bin/lspci -> pciutils; /usr/bin/systemctl -> systemd;
+  /usr/bin/nmcli -> networkmanager; /usr/bin/lscpu -> util-linux;
+  /usr/bin/ip -> iproute2; /usr/bin/lsblk -> util-linux;
+  /bin/bash -> bash
+- Optional: /opt/quest/kace -> ${kacePackage}/opt/quest/kace when
+  linkOptPath = true.
+
+Additionally: `environment.systemPackages = [ pkgs.dmidecode ]`.
+
+Known limitation (code comment): rpm and dpkg-query do not exist on NixOS, so
+KACE INSTALLED_SOFTWARE inventory stays empty ("Only RPM and Debian package
+systems currently supported!"). Fixing this requires a KACE Custom Inventory
+Rule server-side, not a client-side change.
+
+### Services
+
+konea.service (Type=simple daemon):
+- ExecStart: bash -c 'PATH=<finalPath> exec <kaceBinDir>/konea'
+- after/wants network-online.target; wantedBy multi-user.target
+- ExecStartPost: ampConfPatchScript (see above)
+- KillSignal SIGTERM; KillMode control-group; RestartSec 5
+- Restart = always. Rationale (code comment, observed 2026-08-07): an SMA
+  agent-reset tells konea to exit cleanly (exit 0); with on-failure systemd
+  ignores clean exits, leaving the agent dead silently until reboot.
+- User/Group from cfg; WorkingDirectory dataDir; Environment kaceEnv;
+  output to journal.
+
+kschedulerconsole.service (Type=simple):
+- ExecStartPre: sleep 10; ExecStart: bash exec KSchedulerConsole
+- after + requires konea.service; wants network-online.target
+- Restart = always (same clean-exit-on-reset rationale).
+
+### Watchdog (enableWatchdog = true): two timers, NOT long-running services
+
+Design (from code comments): KACE ships AMPWatchDog as periodic cron one-shots
+(AMPWatchDogCrontab, KoneaCheckerCrontab inside the package); the module models
+this as systemd timers. A watchdog must NOT depend on konea.service - if it
+did, it would be stopped whenever konea stops (e.g., agent-reset), which is
+exactly the failure it exists to recover from.
+
+ampwatchdog.timer + ampwatchdog.service:
+- Timer OnCalendar "*-*-* 03,09,15,21:05:00" (every 6h, matches KACE crontab),
+  AccuracySec 1m, Persistent true.
+- Service Type=oneshot; ExecStart <kaceBinDir>/AMPWatchDog.
+
+konea-checker.timer + konea-checker.service:
+- Timer OnCalendar "*-*-* *:00,10,20,30,40,50:00" (every 10 min, matches
+  KoneaCheckerCrontab), AccuracySec 1m, Persistent true.
+- Service Type=oneshot; ExecStart = koneaCheckerScript (writeShellScript):
+  1. Run <kaceBinDir>/AMPWatchDog -k. AMPWatchDog detects systemd and revives
+     konea via systemctl start konea.
+  2. If kschedulerconsole.service is not active, systemctl start it.
+  Rationale: AMPWatchDog -k does NOT restart KSchedulerConsole, but RESETAGENT
+  stops both; konea contains no scheduler logic, so scheduled inventory would
+  silently stop. Mirrors KACE's own AMPctl, which starts both together.
+
+Historical note (git history): earlier iterations ran AMPHealthCheck from the
+timer and ran ampwatchdog as a long-running service requiring konea; replaced
+by the current timer design (commits 6d6443c, cbd1d1c, b41d056).
+
+---
+
+## 5. Usage Examples [derived from option definitions above]
+
+Basic (manual tarball):
+
+```nix
+inputs.kace-ampagent.url = "github:kd2flz/kace-ampagent/main";
+imports = [ kace-ampagent.nixosModules.kace-ampagent ];
+services.kace-ampagent = {
+  enable = true;
+  host = "kbox.example.com";
+};
+# plus: nix store add-file ./ampagent-15.1.45.ubuntu.64.tar.gz
+```
+
+Pure build via URL:
+
+```nix
+services.kace-ampagent = {
+  enable = true;
+  host = "kbox.example.com";
+  packageUrl =
+    "https://github.com/kd2flz/resources/releases/download/15.1.45/ampagent-15.1.45.ubuntu.64.tar.gz";
+};
+```
+
+Fuller example (name override, ampConf, watchdog):
+
+```nix
+services.kace-ampagent = {
+  enable = true;
+  host = "kbox.example.com";
+  name = "web01";
+  ampConf = { org = "Default"; };
+  environment = { KACE_HTTPS = "true"; };
+  enableWatchdog = true;
+};
+```
+
+---
+
+## 6. Development Workflow [README + CI workflow verified]
+
+Build locally (manual tarball path):
+
+```bash
+nix store add-file ./ampagent-15.1.45.ubuntu.64.tar.gz
+nix build .#kace-ampagent
+```
+
+Run binaries manually:
+
+```bash
+./result/opt/quest/kace/bin/konea -help
+./result/opt/quest/kace/bin/runkbot <kbot-id> <version>
+```
+
+Manual runs need psmisc/coreutils reachable; systemd services add them via
+Environment PATH automatically.
+
+CI (.github/workflows/build-kace-ampagent.yml): on push/PR to main,
+installs Nix (cachix/install-nix-action@v27, channel nixos-unstable for the
+installer's nix_path), then:
+
+1. Warns via ::warning:: if KACE_TARBALL_URL is empty.
+2. `nix build --impure .#kace-ampagent-env` - fetches the tarball from
+   KACE_TARBALL_URL (repository secret) when set; otherwise falls back to
+   requireFile, which fails with an instructive message.
+3. Builds a temporary consumer flake that enables services.kace-ampagent and
+   builds the full nixosConfiguration toplevel. The temp flake sets
+   services.kace-ampagent.host = "kbox.invalid" (host is a required option;
+   omitting it broke evaluation) and packageUrl read from KACE_TARBALL_URL.
+   Built with `--impure` so getEnv resolves.
+
+Secret setup: repository Settings -> Secrets and variables -> Actions ->
+New repository secret, name KACE_TARBALL_URL, value = publicly reachable
+tarball URL. Caveat: GitHub does not pass secrets to pull requests opened
+from forks; same-repo branches and pushes get them.
+
+---
+
+## 7. Troubleshooting [each item traced to code]
+
+| Symptom | Cause (verified where) | Resolution |
+|---|---|---|
+| Build error: expected opt/ inside archive | installPhase check in default.nix | Verify tarball layout/version |
+| requireFile error at eval time | Tarball not in store | nix store add-file, or set packageUrl |
+| Hash mismatch on fetchurl | URL serves different bytes | Re-hash and update sha256 in default.nix |
+| konea reports hostname as error string | dangling hostname symlink (git 939c04f/7d1b259) | Fixed by direct store-path symlinks; verify tmpfiles rules applied |
+| Last Inventory never advances, no visible errors | 0-CPU inventory discarded by SMA (module comment) | Ensure kacePath tools present; check journal for konea-checker activity |
+| Agent dies hours after SMA agent-reset | clean exit + Restart=on-failure (old behavior) | Fixed: Restart=always; ensure you are on current module |
+| name= keeps reverting | KBOX config push clobbers amp.conf | Handled by ampConfPatchScript; check konea.service ExecStartPost logs |
+| INSTALLED_SOFTWARE empty | no rpm/dpkg-query on NixOS (module comment) | Server-side Custom Inventory Rule required |
+
+---
+
+## 8. Version History [git history]
+
+- 15.0.54: initial packaged version (requireFile only).
+- 2026-08-23 (uncommitted work on dev): version bump to 15.1.45, optional
+  `url` parameter added to package (fetchurl path), new module option
+  `services.kace-ampagent.packageUrl`, agents.md created.
+
+---
+
+## 9. External References [public URLs]
+
+- Quest KB: generic Linux agent download
+  https://support.quest.com/kb/4272341/how-to-find-and-install-the-generic-linux-agent-for-sma
+- NixOS modules: https://nixos.org/manual/nixos/stable/index.html#ch-modules
+- Nix fetchurl: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-fetchurl.html
+- Nixpkgs requireFile: https://nixos.org/manual/nixpkgs/stable/#sec-file-requirements
+- systemd.service: https://www.freedesktop.org/software/systemd/man/systemd.service.html
+
+---
+
+## 10. Known Documentation Drift (README vs code)
+
+The README describes two one-shot services that do NOT exist in any version
+of modules/services/kace-ampagent.nix checked into git:
+
+- kace-ampagent-setup.service
+- kace-ampagent-initial-config.service (and its .initial-config-done marker)
+
+Actual behavior: amp.conf is managed by the activation script + ExecStartPost
+patch script (section 4); enrollment happens through normal konea operation.
+Do not rely on those service names when debugging. Consider updating README.

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,18 @@
     packages = forAllSystems (pkgs: {
       default = pkgs.kace-ampagent;
       kace-ampagent = pkgs.kace-ampagent;
+
+      # CI helper: honors KACE_TARBALL_URL when built with `--impure`
+      # (e.g. `nix build --impure .#kace-ampagent-env`). Without the variable,
+      # or in pure eval, it behaves exactly like kace-ampagent (requireFile).
+      kace-ampagent-env =
+        let
+          res = builtins.tryEval (builtins.getEnv "KACE_TARBALL_URL");
+          url = if res.success && res.value != "" then res.value else null;
+        in
+        if url == null
+        then pkgs.kace-ampagent
+        else pkgs.kace-ampagent.override { inherit url; };
     });
 
     nixosModules.kace-ampagent = { ... }: {

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -5,6 +5,9 @@ let
     mkOption mkEnableOption mkIf types
     mapAttrsToList concatStringsSep optional filterAttrs;
 
+  # Use custom package with URL if provided
+  kacePackage = if cfg.packageUrl != null then pkgs.kace-ampagent.override { url = cfg.packageUrl; } else cfg.package;
+
   # Ensure required tools are in PATH for script execution.
   # This PATH is inherited by konea's /exec spawn chain (konea -> KPlugins ->
   # runkbot -> KBoxClient -> KInventory): konea does NOT sanitise it. Verified
@@ -41,7 +44,7 @@ let
   kaceEnv = [ "PATH=${finalPath}" ] ++ mapAttrsToList (n: v: "${n}=${v}") envWithoutPath;
 
   # Path to kace binaries
-  kaceBinDir = "${cfg.package}/opt/quest/kace/bin";
+  kaceBinDir = "${kacePackage}/opt/quest/kace/bin";
 
   # Wrapper for the 10-min konea checker. AMPWatchDog -k revives konea (it
   # detects systemd and does `systemctl start konea`), but it does NOT restart
@@ -82,6 +85,13 @@ in
       type = types.package;
       default = pkgs.kace-ampagent;
       description = "Package containing KACE agent tree (e.g., tarball install under /opt/quest/kace).";
+    };
+
+    packageUrl = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "https://github.com/kd2flz/resources/releases/download/15.1.45/ampagent-15.1.45.ubuntu.64.tar.gz";
+      description = "Optional URL to fetch the agent tarball for pure builds. If set, overrides the package source via pkgs.kace-ampagent.override { url = ... }.";
     };
 
     user = mkOption {
@@ -197,7 +207,7 @@ in
         # Not fixable this way: rpm / dpkg-query do not exist on NixOS, so
         # INSTALLED_SOFTWARE stays empty ("Only RPM and Debian package systems
         # currently supported!"). Needs a KACE Custom Inventory Rule instead.
-      ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${cfg.package}/opt/quest/kace";
+      ] ++ optional cfg.linkOptPath "L+ /opt/quest/kace - - - - ${kacePackage}/opt/quest/kace";
 
     # === Write NixOS-managed keys into amp.conf at activation time ===
     # Handles initial setup and ensures host= is always correct.

--- a/pkgs/kace-ampagent/default.nix
+++ b/pkgs/kace-ampagent/default.nix
@@ -3,15 +3,18 @@
 , lib
 , autoPatchelfHook
 , requireFile
+, fetchurl
 , makeWrapper
 , psmisc
 , coreutils
+, url ? null
 , ...
 }:
 
 let
-  version = "15.0.54";
+  version = "15.1.45";
   agentFileName = "ampagent-${version}.ubuntu.64.tar.gz";
+  defaultUrl = "https://github.com/kd2flz/resources/releases/download/${version}/${agentFileName}";
 
   # Minimal LSB init-functions for NixOS (scripts expect /lib/lsb/init-functions)
   lsbInitFunctions = builtins.toFile "lsb-init-functions" ''
@@ -66,17 +69,28 @@ let
     }
   '';
 
-  agentSrc = requireFile {
-    name = agentFileName;
-    sha256 = "sha256-HrJp31TNW605PL7hjsCvjJFLG9PP94ARvomcpybOwDQ=";
-    message = ''
-      The Quest KACE AMP Agent generic Linux tarball is required but not provided.
+  agentSrc = if url != null then
+    fetchurl {
+      inherit url;
+      sha256 = "sha256-nkCcTIKybOJCytZzYXrrkjW6KK3pPa02z/oBLEW0hB0=";
+    }
+  else
+    requireFile {
+      name = agentFileName;
+      sha256 = "sha256-nkCcTIKybOJCytZzYXrrkjW6KK3pPa02z/oBLEW0hB0=";
+      message = ''
+        The Quest KACE AMP Agent generic Linux tarball is required but not provided.
 
-      1) Download: ${agentFileName} - see https://support.quest.com/kb/4272341/how-to-find-and-install-the-generic-linux-agent-for-sma
-      2) nix store add-file ${agentFileName}
-      3) Re-run:    nix build .#kace-ampagent
-    '';
-  };
+        Option 1 (manual):
+        1) Download: ${agentFileName} - see https://support.quest.com/kb/4272341/how-to-find-and-install-the-generic-linux-agent-for-sma
+        2) nix store add-file ${agentFileName}
+        3) Re-run:    nix build .#kace-ampagent
+
+        Option 2 (pure build via URL):
+        Pass the url parameter, e.g.:
+        (import ./pkgs/kace-ampagent { url = "${defaultUrl}"; })
+      '';
+    };
 in
 stdenv.mkDerivation {
   pname = "kace-ampagent";


### PR DESCRIPTION
…requireFile forced manual 'nix store add-file' before every build, so the package now takes a url param (fetchurl, same pinned sha256) exposed as services.kace-ampagent.packageUrl; CI fetches via KACE_TARBALL_URL secret (.#kace-ampagent-env, --impure) and sets host+packageUrl in the module-validation flake; drop --print-build-logs so the URL stays out of logs; add agents.md documenting architecture, watchdog timers, amp.conf patching and known README drift

#22 