### PR TITLE
Add hostFile option so KACE SMA host can stay out of the Nix store

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ The `kace-ampagent-env` output falls back to `requireFile` behavior when the var
 -   `services.kace-ampagent.logDir`: The directory where the agent stores its logs (string, default `/var/log/quest/kace`).
 -   `services.kace-ampagent.environment`: An attribute set of extra environment variables for the agent (attrset, default `{}`).
 -   `services.kace-ampagent.linkOptPath`: Create a `/opt/quest/kace` symlink pointing to the package content for compatibility (boolean, default `true`).
--   `services.kace-ampagent.host`: The KACE SMA host (string, required). Written to `amp.conf` as `host=`.
+-   `services.kace-ampagent.host`: The KACE SMA host, given directly as a plain string (nullable string, default `null`). Written to `amp.conf` as `host=`. Interpolated into the activation script at eval time - fine for a non-secret hostname, but it means the value is stored in plain text in the resulting activation-script derivation in `/nix/store`. Mutually exclusive with `hostFile`; exactly one of the two must be set.
+-   `services.kace-ampagent.hostFile`: Path to a file containing the KACE SMA host (nullable path, default `null`), read with `cat` at activation *runtime* instead of being interpolated into the activation script at eval time. Use this - e.g. pointed at a sops-nix secret path (`config.sops.secrets."kace/host".path`) - when the hostname must not appear in the Nix store or any `.drv`. Mutually exclusive with `host`; exactly one of the two must be set.
 -   `services.kace-ampagent.name`: Machine name reported to KBOX (string, default: `networking.hostName`). Written to `amp.conf` as `name=` and re-applied after each konea start (see Service Behavior).
 -   `services.kace-ampagent.ampConf`: An attribute set of additional key-value pairs for `amp.conf` (attrset, default `{}`).
 -   `services.kace-ampagent.enableWatchdog`: Enable `AMPWatchDog` via systemd timers (boolean, default `false`). Creates `ampwatchdog.timer` (every 6 h, matching `AMPWatchDogCrontab`) and `konea-checker.timer` (every 10 min, matching `KoneaCheckerCrontab`). The watchdog one-shots intentionally do NOT depend on `konea.service`, so they still run and restart konea after an SMA agent-reset. The 10 min `konea-checker` additionally restarts `KSchedulerConsole` if it is not running, because `AMPWatchDog -k` only revives konea - leaving the scheduler (which drives scheduled inventory/scripts) dead after a reset.
@@ -144,6 +145,28 @@ services.kace-ampagent = {
     # Other settings like CERT_VALIDATION, etc.
   };
   enableWatchdog = true; # Optional: watchdog + konea-checker timers
+};
+```
+
+### Keeping the host confidential (`hostFile`)
+
+If your SMA hostname shouldn't be readable in the Nix store (e.g. it leaks
+internal infrastructure naming), use `hostFile` instead of `host`. It's read
+with `cat` at activation runtime rather than interpolated into the Nix
+string / activation-script derivation, so the value never lands in a `.drv`
+or gets copied by `nix copy`/binary caches. This pairs naturally with
+sops-nix, which decrypts secrets to disk at activation time (not eval time),
+keeping the whole chain pure and secret-free in the store:
+
+```nix
+services.kace-ampagent = {
+  enable = true;
+  hostFile = config.sops.secrets."kace/host".path; # NOT `host`
+};
+
+sops.secrets."kace/host" = {
+  sopsFile = ../secrets/kace.yaml;
+  key = "host";
 };
 ```
 

--- a/agents.md
+++ b/agents.md
@@ -118,7 +118,8 @@ Namespace: `services.kace-ampagent.*`. Everything below only applies when
 | group | str | "root" | Service group |
 | dataDir | str | "/var/quest/kace" | amp.conf lives here |
 | logDir | str | "/var/log/quest/kace" | Log directory |
-| host | str | (no default) | Written to amp.conf as host= |
+| host | nullOr str | null | Written to amp.conf as host=; interpolated at eval time (plaintext in the activation-script .drv). Mutually exclusive w/ hostFile; assertion requires exactly one of host/hostFile |
+| hostFile | nullOr path | null | NEW 2026-08-25: path read via `cat` at activation *runtime* instead of eval time, for host= without the value entering the Nix store (e.g. a sops-nix secret path). Mutually exclusive w/ host |
 | name | str | config.networking.hostName | Machine name reported to KBOX (name= key) |
 | ampConf | attrsOf str | {} | Extra key=value lines for amp.conf |
 | environment | attrsOf str | {} | Extra env vars; PATH gets special handling below |
@@ -155,9 +156,13 @@ environment attrs become Environment= entries on every service.
 ### amp.conf management (two mechanisms)
 
 1. Activation script `system.activationScripts.kace-ampconf` (runs at system
-   activation): ensures dataDir exists and amp.conf exists, then upserts keys:
-   `host = cfg.host`, `name = cfg.name`, plus every cfg.ampConf pair.
-   Upsert = sed replace-in-place if key exists, else append line.
+   activation): ensures dataDir exists and amp.conf exists, then upserts keys.
+   `host=` is handled by its own branch (NOT the generic map, since 2026-08-25):
+   if `cfg.hostFile != null`, the script does `HOST_VALUE="$(cat "${cfg.hostFile}")"`
+   at shell *runtime* and upserts with that; otherwise `cfg.host` is interpolated
+   directly into the sed/printf commands at Nix *eval* time (same as before).
+   The name=/ampConf map is separate and unconditional: `name = cfg.name` plus
+   every cfg.ampConf pair, upsert = sed replace-in-place if key exists else append.
 2. ExecStartPost on konea.service runs `ampConfPatchScript`: sleeps 30s, then
    re-applies `name = cfg.name` plus all cfg.ampConf keys with the same upsert
    logic. Reason: KBOX pushes a fresh amp.conf down shortly after konea

--- a/modules/services/kace-ampagent.nix
+++ b/modules/services/kace-ampagent.nix
@@ -119,9 +119,28 @@ in
     };
 
     host = mkOption {
-      type = types.str;
+      type = types.nullOr types.str;
+      default = null;
       example = "kbox.example.com";
-      description = "KACE SMA host (written to amp.conf).";
+      description = ''
+        KACE SMA host (written to amp.conf), given directly as a plain string.
+        Mutually exclusive with `hostFile`. Exactly one of `host` or `hostFile`
+        must be set.
+      '';
+    };
+
+    hostFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/kace-host";
+      description = ''
+        Path to a file containing the KACE SMA host, read at activation
+        *runtime* (e.g. via `cat`) rather than interpolated into the Nix
+        string / activation script at eval time. Use this instead of `host`
+        when the hostname must not appear in the Nix store or in any `.drv`
+        (e.g. a sops-nix secret path). Mutually exclusive with `host`.
+        Exactly one of `host` or `hostFile` must be set.
+      '';
     };
 
     name = mkOption {
@@ -157,6 +176,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (cfg.host != null) != (cfg.hostFile != null);
+        message = "services.kace-ampagent: exactly one of `host` or `hostFile` must be set.";
+      }
+    ];
+
     # === Users/groups and directories ===
     users.groups = mkIf (cfg.group != "root") {
       "${cfg.group}" = { };
@@ -214,17 +240,43 @@ in
     # Note: KBOX pushes a fresh amp.conf on every konea connection, which
     # clobbers keys like name=. The ExecStartPost on konea re-applies them
     # 30 s after start (after the KBOX push settles).
+    #
+    # host= is upserted separately from the name=/ampConf map below so that
+    # `hostFile` (e.g. a sops-nix secret path) can be `cat`-ed at shell
+    # *runtime* instead of being interpolated into this script as a Nix
+    # string at *eval* time. Interpolating a value here bakes it in plain
+    # text into the activation script derivation in /nix/store (world
+    # readable, cached, copied on `nix copy`) -- fine for non-secret values
+    # like `host`, but defeats the point of a secret if `hostFile` is used.
     system.activationScripts.kace-ampconf = ''
       mkdir -p "${cfg.dataDir}"
       CONF="${cfg.dataDir}/amp.conf"
       touch "$CONF"
+
+      ${
+        if cfg.hostFile != null then ''
+          HOST_VALUE="$(cat "${cfg.hostFile}")"
+          if ${pkgs.gnugrep}/bin/grep -q "^host=" "$CONF"; then
+            ${pkgs.gnused}/bin/sed -i "s|^host=.*|host=$HOST_VALUE|" "$CONF"
+          else
+            printf 'host=%s\n' "$HOST_VALUE" >> "$CONF"
+          fi
+        '' else ''
+          if ${pkgs.gnugrep}/bin/grep -q "^host=" "$CONF"; then
+            ${pkgs.gnused}/bin/sed -i 's|^host=.*|host=${cfg.host}|' "$CONF"
+          else
+            printf 'host=%s\n' '${cfg.host}' >> "$CONF"
+          fi
+        ''
+      }
+
       ${concatStringsSep "\n" (mapAttrsToList (k: v: ''
         if ${pkgs.gnugrep}/bin/grep -q "^${k}=" "$CONF"; then
           ${pkgs.gnused}/bin/sed -i 's|^${k}=.*|${k}=${v}|' "$CONF"
         else
           printf '%s\n' '${k}=${v}' >> "$CONF"
         fi
-      '') ({ host = cfg.host; name = cfg.name; } // cfg.ampConf))}
+      '') ({ name = cfg.name; } // cfg.ampConf))}
     '';
 
     # === konea: runs as daemon with -start ===


### PR DESCRIPTION
Enables passing path to SMA host as a SOPS secret in the consuming module.